### PR TITLE
Improve EKF with robot-robot corrections

### DIFF
--- a/cooperative_localization/include/data_loader.h
+++ b/cooperative_localization/include/data_loader.h
@@ -54,6 +54,9 @@ public:
     // Carica la mappa dei landmark
     bool loadLandmarkGroundtruth(const std::string& filename);
 
+    // Carica la tabella che associa barcode a ID di soggetto
+    bool loadBarcodes(const std::string& filename);
+
     // Carica i dati di odometria per un dato robot
     bool loadOdometry(const std::string& filename, int robot_id);
 
@@ -69,6 +72,7 @@ public:
 private:
     std::vector<Event> event_queue;
     std::map<int, Landmark> landmark_map;
+    std::map<int, int> barcode_to_subject_;
 };
 
 #endif // DATA_LOADER_H

--- a/cooperative_localization/include/ekf_centralized.h
+++ b/cooperative_localization/include/ekf_centralized.h
@@ -16,7 +16,7 @@ public:
     
     const Eigen::VectorXd& getState() const { return state_; }
     const Eigen::MatrixXd& getCovariance() const { return P_; }
-    void printState(rclcpp::Logger logger) const;
+    void printState(rclcpp::Logger logger, double timestamp) const;
     void printUncertainty(rclcpp::Logger logger) const;
     void setState(const Eigen::VectorXd& new_state);
 
@@ -28,6 +28,7 @@ private:
     Eigen::MatrixXd P_;
     Eigen::MatrixXd Q_;
     Eigen::MatrixXd R_landmark_;
+    Eigen::MatrixXd R_robot_;
     
     int num_robots_;
     std::map<int, Landmark> landmark_map_;


### PR DESCRIPTION
## Summary
- map barcode IDs to subjects when loading measurements
- support loading barcode table
- implement robot-to-robot correction and gating in `EkfCentralized`
- output timestamp when printing EKF state
- update centralized node to load barcodes and use new features

## Testing
- `cmake ../cooperative_localization` *(fails: could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_688b8c3bcf6483278f4d769b0d91b78e